### PR TITLE
Rebuild for defaults

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 358f1616db479b8272b74fb7d5f10f93dfc695a264137dd1959b50b50dcd6346
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 


### PR DESCRIPTION
12.40.0

**Destination channel:** defaults

### Links

- [PKG-8020](https://anaconda.atlassian.net/browse/PKG-8020)
- [Upstream repository](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-file-datalake)
- Relevant dependency PRs:
  - AnacondaRecipes/cloudpathlib-feedstock#4

### Explanation of changes:

- Release to default channels


[PKG-8020]: https://anaconda.atlassian.net/browse/PKG-8020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ